### PR TITLE
Add trace storage from /user

### DIFF
--- a/quarkus-superapp/src/main/java/com/superapp/TraceResource.java
+++ b/quarkus-superapp/src/main/java/com/superapp/TraceResource.java
@@ -1,0 +1,25 @@
+package com.superapp;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.superapp.trace.TraceContext;
+
+/**
+ * Endpoint that returns an ASCII trace of the request flow.
+ */
+@Path("/trace")
+@Produces(MediaType.TEXT_PLAIN)
+public class TraceResource {
+
+    @Inject
+    TraceContext trace;
+
+    @GET
+    public String trace() {
+        return trace.getLastDump();
+    }
+}

--- a/quarkus-superapp/src/main/java/com/superapp/trace/TraceContext.java
+++ b/quarkus-superapp/src/main/java/com/superapp/trace/TraceContext.java
@@ -1,0 +1,35 @@
+package com.superapp.trace;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Simple per-thread trace collector for demo purposes.
+ */
+@ApplicationScoped
+public class TraceContext {
+    private ThreadLocal<List<String>> traces = ThreadLocal.withInitial(ArrayList::new);
+    private volatile String lastDump = "";
+
+    public void clear() {
+        traces.get().clear();
+    }
+
+    public void record(String step) {
+        traces.get().add(step);
+    }
+
+    public String dump() {
+        lastDump = traces.get().stream()
+                .map(s -> "-> " + s)
+                .collect(Collectors.joining("\n"));
+        return lastDump;
+    }
+
+    public String getLastDump() {
+        return lastDump;
+    }
+}

--- a/quarkus-superapp/src/test/java/com/superapp/TraceResourceTest.java
+++ b/quarkus-superapp/src/test/java/com/superapp/TraceResourceTest.java
@@ -1,0 +1,35 @@
+package com.superapp;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import com.superapp.framework.SuperApp;
+
+@QuarkusTest
+public class TraceResourceTest {
+
+    @Inject
+    TestUserService testService;
+
+    @Inject
+    SuperApp app;
+
+    @Test
+    public void testTraceEndpoint() {
+        testService.setScenario(TestUserService.Scenario.SUCCESS);
+        RestAssured.given().body("{\"user\":\"ana\"}").contentType("application/json")
+                .when().post("/user")
+                .then()
+                .statusCode(200);
+
+        RestAssured.get("/trace")
+                .then()
+                .statusCode(200)
+                .body(CoreMatchers.containsString("OnInCommingCall"))
+                .body(CoreMatchers.containsString("result:"));
+    }
+}


### PR DESCRIPTION
## Summary
- store last trace dump in `TraceContext`
- capture trace steps in `UserResource`
- expose `/trace` endpoint to read last trace
- adjust the trace endpoint test

## Testing
- `mvn -q -f quarkus-superapp/pom.xml test` *(fails: Could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f117ca89c833389996028546fb559