### PR TITLE
Add runnable jar build and sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,32 @@ You can see a basic mock implementation in the accompanying Quarkus example.
 
 A sample Quarkus project lives in the `quarkus-superapp` directory.
 It injects a mock `SuperApp` instance with CDI so you can explore the
-recommended service settings in Java.
+recommended service settings in Java. Source files are under
+`quarkus-superapp/src/main/java`.
+
+### Building the example
+
+The pom generates a runnable jar for local testing. Build it with:
+
+```bash
+mvn package -f quarkus-superapp/pom.xml
+```
+
+Run the application:
+
+```bash
+java -jar quarkus-superapp/target/superapp-quarkus-1.0.0-SNAPSHOT-runner.jar
+```
+
+### Trying the endpoints
+
+Request a user and inspect the trace:
+
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"user":"ana"}' http://localhost:8080/user
+curl http://localhost:8080/trace
+```
 
 ## Continuous Integration
 

--- a/quarkus-superapp/pom.xml
+++ b/quarkus-superapp/pom.xml
@@ -14,6 +14,8 @@
         <quarkus.platform.version>2.16.5.Final</quarkus.platform.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <!-- build a single runnable jar so it can be executed locally -->
+        <quarkus.package.type>uber-jar</quarkus.package.type>
     </properties>
 
     <dependencyManagement>

--- a/quarkus-superapp/src/main/resources/application.properties
+++ b/quarkus-superapp/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.http.host=0.0.0.0
+quarkus.http.port=8080


### PR DESCRIPTION
## Summary
- enable `uber-jar` packaging in the Quarkus example pom
- expand README with build steps and example curl commands
- add application.properties to bind IO to `0.0.0.0` on port `8080`

## Testing
- `timeout 20 mvn -f quarkus-superapp/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686f1b3fa8c88333ac0795776b11e0a2