### PR TITLE
Implement trace history

### DIFF
--- a/quarkus-superapp/src/main/java/com/superapp/UserResource.java
+++ b/quarkus-superapp/src/main/java/com/superapp/UserResource.java
@@ -14,7 +14,6 @@ import javax.ws.rs.core.Response;
 
 import com.superapp.framework.ServiceRuntime;
 import com.superapp.service.UserService;
-import com.superapp.trace.TraceContext;
 
 @Path("/user")
 @Produces(MediaType.APPLICATION_JSON)
@@ -27,8 +26,6 @@ public class UserResource {
     @Inject
     UserService service;
 
-    @Inject
-    TraceContext trace;
 
     @POST
     public Response getUser(UserRequest request) throws Exception {
@@ -37,15 +34,15 @@ public class UserResource {
         try {
             Optional<String> data = runtime.handleOutgoingCall(() -> service.fetchUser(request.user));
             if (data.isPresent()) {
-                trace.record("result: " + data.get());
+                runtime.recordResult(data.get());
                 runtime.getTrace();
                 return Response.ok("{\"data\":\"" + data.get() + "\"}").build();
             }
-            trace.record("result: not found");
+            runtime.recordResult("not found");
             runtime.getTrace();
             return Response.status(Response.Status.NOT_FOUND).entity("not found").build();
         } catch (TimeoutException | IOException e) {
-            trace.record("error: " + e.getClass().getSimpleName());
+            runtime.recordError(e.getClass().getSimpleName());
             runtime.getTrace();
             return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity("error").build();
         }

--- a/quarkus-superapp/src/main/java/com/superapp/framework/ServiceRuntime.java
+++ b/quarkus-superapp/src/main/java/com/superapp/framework/ServiceRuntime.java
@@ -54,7 +54,7 @@ public class ServiceRuntime {
 
     public void startTrace() {
         trace.clear();
-        trace.record("start request");
+        trace.recordAuto("start request");
     }
 
     public String getTrace() {
@@ -62,21 +62,21 @@ public class ServiceRuntime {
     }
 
     public void handleIncomingRequest() {
-        trace.record("handleIncomingRequest: healthy=" + serviceHealthy + ", throttled=" + throttleActive);
+        trace.recordAuto("handleIncomingRequest: healthy=" + serviceHealthy + ", throttled=" + throttleActive);
         // logic when web request arrives
     }
 
     public <T> T handleOutgoingCall(Callable<T> call) throws Exception {
-        trace.record("handleOutgoingCall: start");
+        trace.recordAuto("handleOutgoingCall: start");
         try {
             T result = call.call();
-            trace.record("handleOutgoingCall: success");
+            trace.recordAuto("handleOutgoingCall: success");
             if (throttleActive) {
                 recoverService();
             }
             return result;
         } catch (TimeoutException | IOException e) {
-            trace.record("handleOutgoingCall: " + e.getClass().getSimpleName());
+            trace.recordAuto("handleOutgoingCall: " + e.getClass().getSimpleName());
             activateThrottle();
             throw e;
         }
@@ -85,12 +85,23 @@ public class ServiceRuntime {
     public void activateThrottle() {
         throttleActive = true;
         serviceHealthy = false;
-        trace.record("activateThrottle -> throttled");
+        trace.recordAuto("activateThrottle -> throttled");
     }
 
     public void recoverService() {
         throttleActive = false;
         serviceHealthy = true;
-        trace.record("recoverService -> healthy");
+        trace.recordAuto("recoverService -> healthy");
+    }
+
+    /**
+     * Record the final result of the request.
+     */
+    public void recordResult(String result) {
+        trace.recordAuto("result: " + result);
+    }
+
+    public void recordError(String error) {
+        trace.recordAuto("error: " + error);
     }
 }

--- a/quarkus-superapp/src/main/java/com/superapp/trace/TraceContext.java
+++ b/quarkus-superapp/src/main/java/com/superapp/trace/TraceContext.java
@@ -1,18 +1,27 @@
 package com.superapp.trace;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.lang.StackWalker;
+import java.lang.StackWalker.StackFrame;
 
 import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Simple per-thread trace collector for demo purposes.
+ * <p>
+ * The context now stores the last ten completed request flows so that the
+ * /trace endpoint can display recent activity.
  */
 @ApplicationScoped
 public class TraceContext {
     private ThreadLocal<List<String>> traces = ThreadLocal.withInitial(ArrayList::new);
-    private volatile String lastDump = "";
+    private Deque<List<String>> history = new ArrayDeque<>();
+    private AtomicInteger counter = new AtomicInteger();
 
     public void clear() {
         traces.get().clear();
@@ -22,14 +31,56 @@ public class TraceContext {
         traces.get().add(step);
     }
 
-    public String dump() {
-        lastDump = traces.get().stream()
-                .map(s -> "-> " + s)
-                .collect(Collectors.joining("\n"));
-        return lastDump;
+    public void record(String step, Class<?> clazz, String method) {
+        traces.get().add(step + " [" + clazz.getSimpleName() + ", " + method + "]");
     }
 
-    public String getLastDump() {
-        return lastDump;
+    /**
+     * Record a step automatically tagging the calling class and method.
+     */
+    public void recordAuto(String step) {
+        StackFrame frame = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+                .walk(s -> s.skip(2).findFirst()).orElse(null);
+        if (frame != null) {
+            traces.get().add(step + " [" + frame.getDeclaringClass().getSimpleName() + ", " + frame.getMethodName() + "]");
+        } else {
+            traces.get().add(step);
+        }
+    }
+
+    /**
+     * Dump the current trace and add it to the history of recent traces.
+     */
+    public synchronized String dump() {
+        List<String> copy = new ArrayList<>(traces.get());
+        history.addLast(copy);
+        if (history.size() > 10) {
+            history.removeFirst();
+        }
+        counter.incrementAndGet();
+        String dump = copy.stream()
+                .map(s -> "##-> " + s)
+                .collect(Collectors.joining("\n"));
+        traces.get().clear();
+        return dump;
+    }
+
+    /**
+     * Return a dump of the last ten recorded traces.
+     */
+    public synchronized String getLastDump() {
+        int startId = counter.get() - history.size() + 1;
+        int id = startId;
+        StringBuilder sb = new StringBuilder();
+        for (List<String> trace : history) {
+            sb.append("# Request: ").append(id).append('\n');
+            sb.append("## Request count: ").append(id).append('\n');
+            sb.append(trace.stream()
+                    .map(s -> "##-> " + s)
+                    .collect(Collectors.joining("\n")));
+            sb.append("\n\n");
+            id++;
+        }
+        return sb.toString().trim();
     }
 }

--- a/quarkus-superapp/src/test/java/com/superapp/TraceResourceTest.java
+++ b/quarkus-superapp/src/test/java/com/superapp/TraceResourceTest.java
@@ -29,7 +29,7 @@ public class TraceResourceTest {
         RestAssured.get("/trace")
                 .then()
                 .statusCode(200)
-                .body(CoreMatchers.containsString("handleIncomingRequest"))
+                .body(CoreMatchers.containsString("Request count: 1"))
                 .body(CoreMatchers.containsString("result:"));
     }
 }


### PR DESCRIPTION
## Summary
- store last 10 traces and format with request info
- log class/method in trace steps
- update tests for new trace output
- encapsulate trace recording in ServiceRuntime to simplify user code

## Testing
- `mvn -q -f quarkus-superapp/pom.xml test` *(fails: dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686f27fafe88833394727aef3f98d72b